### PR TITLE
use short circuit or instead of junction in attr-value

### DIFF
--- a/lib/DOM/Tiny/HTML.pm6
+++ b/lib/DOM/Tiny/HTML.pm6
@@ -41,9 +41,9 @@ grammar XMLTokenizer {
     }
     token attr-key { <-[ < > = \s / ]>+ }
     token attr-value {
-        | [ '"' $<raw-value> = [ .*? ] '"'  ]
-        | [ "'" $<raw-value> = [ .*? ] "'" ]
-        | [ $<raw-value> = <-[ > \s ]>* ]
+        || [ '"' $<raw-value> = [ .*? ] '"'  ]
+        || [ "'" $<raw-value> = [ .*? ] "'" ]
+        || [ $<raw-value> = <-[ > \s ]>* ]
     }
     token attr-broken {
         [


### PR DESCRIPTION
It appears that using short circuit or instead of junction improves performance of the parser up to 4 times